### PR TITLE
Frontend/request formatting

### DIFF
--- a/client/src/components/Requests.tsx
+++ b/client/src/components/Requests.tsx
@@ -19,8 +19,7 @@ export default function Requests() {
   }, [encoded_id])
 
   if (!encoded_id) return <p>Error: Missing Tub Id.</p>
-  
-  console.log(requests)
+
   return (
     <>
       <PageHeader />

--- a/client/src/components/Requests.tsx
+++ b/client/src/components/Requests.tsx
@@ -55,12 +55,16 @@ function Request({request}: RequestProps) {
       <div>TIME: {time}</div>
       <div>
         <ToggleInfo title="Headers">
-          <p>{JSON.stringify(request.headers)}</p>
+          <pre>
+            <code>{JSON.stringify(request.headers, null, 2)}</code>
+          </pre>
         </ToggleInfo>
       </div>
       <div>
         <ToggleInfo title="Body">
-          <p>{JSON.stringify(request.body)}</p>
+          <pre>
+            <code>{JSON.stringify(request.body, null, 2)}</code>
+          </pre>
         </ToggleInfo>
       </div>
     </div>

--- a/client/src/components/Requests.tsx
+++ b/client/src/components/Requests.tsx
@@ -25,7 +25,13 @@ export default function Requests() {
     <>
       <PageHeader />
       <RequestHeader encoded_id={encoded_id} requestsLength={requests.length} />
-      {requests.map(request => <Request key={request.id} request={request}/>)}
+      {requests.map(request => (
+        <Request
+          key={request.id}
+          request={request}
+          onDelete={(id) => setRequests(prev => prev.filter(r => r.id !== id))}
+        />
+      ))}
     </>
   )
 }
@@ -43,10 +49,20 @@ function ToggleInfo({ title, children }: ToggleInfoProps) {
   );
 }
 
-function Request({request}: RequestProps) {
+function Request({request, onDelete}: RequestProps) {
   const methodClass = `${request.method.toLowerCase()}`
   const date = new Date(request.timestamp).toLocaleDateString()
   const time = new Date(request.timestamp).toLocaleTimeString()
+
+  const handleDelete = async () => {
+    try {
+      await tubService.deleteRequest(request.id)
+      console.log('Request deleted')
+      if (onDelete) onDelete(request.id)
+    } catch (err) {
+      console.error('Error deleting request:', err)
+    }
+  }
 
   return (
     <div className={"request"}>
@@ -67,6 +83,9 @@ function Request({request}: RequestProps) {
           </pre>
         </ToggleInfo>
       </div>
+      <button className="delete-button" onClick={handleDelete}>
+        Delete Request
+      </button>
     </div>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -239,3 +239,17 @@ button:focus-visible {
   align-items: center;
   gap: 0.3em;
 }
+
+.delete-button {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background-color: #cc0000;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  background-color: #990000;
+}

--- a/client/src/services/tubService.ts
+++ b/client/src/services/tubService.ts
@@ -17,6 +17,11 @@ const createTub = () => {
   return request.then(response => response.data)
 }
 
+const deleteRequest = (requestId: number) => {
+  const request = axios.delete(`/api/requests/${requestId}`)
+  return request.then(response => response.data)
+}
+
 export default {
-  getAll, getRequests, createTub
+  getAll, getRequests, createTub, deleteRequest,
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -20,6 +20,7 @@ export interface MyTubsProps {
 
 export interface RequestProps {
   request: Request;
+  onDelete?: (id: number) => void
 }
 
 export interface ToggleInfoProps {


### PR DESCRIPTION
## What I did
#### reformatted request headers and responses to have new lines
#### Added a delete button that removes a request from the UI and the backend
- added `deleteRequest` method to call the backend API (/api/requests/:id)
- added an optional `onDelete` prop to the Request component that , if passed, invokes the setRequests method which re-renders the page with an updated requests array.

## Actions to take
Should be able to see this functionality immediately.