### PR TITLE
Fix Hard Refresh

### DIFF
--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -54,7 +54,6 @@ export default function Home() {
     setDisplayModal(false)
   }
 
-
   return (
     <>
       <PageHeader />
@@ -62,7 +61,7 @@ export default function Home() {
         <MyTubs tubs={tubs}/>
         <NewTub onClick={handleClick}/>
       </div>
-      {displayModal && <Modal onClose={handleClose} newTubId={newTubId}/>}
+      {displayModal && newTubId && <Modal onClose={handleClose} newTubId={newTubId}/>}
     </>
 
   )

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,7 +1,8 @@
 import ReactDOM from 'react-dom'
 import { useNavigate } from 'react-router-dom'
+import type { ModalProps } from '../types'
 
-export default function Modal({ onClose, newTubId }) {
+export default function Modal({ onClose, newTubId }: ModalProps) {
   const navigate = useNavigate()
 
   const handleOpenTub = () => {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -32,3 +32,8 @@ export interface RequestHeaderProps {
   encoded_id: string;
   requestsLength: number;
 }
+
+export interface ModalProps {
+  onClose: () => void;
+  newTubId: number;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,7 +10,17 @@ app.use('/', router)
 const PORT = 3000;
 
 const CLIENT_DIST_PATH = path.join(__dirname, '..', 'client', 'dist');
+const CLIENT_INDEX_PATH = path.join(CLIENT_DIST_PATH, 'index.html')
 app.use(express.static(CLIENT_DIST_PATH));
+
+app.get(/.*/, (req, res) => {
+  // Only serve index.html for non-API routes
+  if (!req.path.startsWith('/api/') && !req.path.startsWith('/receive/')) {
+    res.sendFile(CLIENT_INDEX_PATH)
+  } else {
+    res.status(404).json({ error: 'Not found' })
+  }
+})
 
 app.listen(PORT, async () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- fixed hard refresh issue by adding catch all route in `index.ts` for the server.
- added missing types for Modal component (was blocking `npm build`)